### PR TITLE
Simple logstash formatter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Vokal
+Copyright (c) 2015 Vokal LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
-# logstash-go
+# logstash
+
+Simple formatter for Logstash
+
+## Example
+
+```go
+conn, err := net.Dial("tcp", "localhost:3333")
+if err != nil {
+    log.Fatal(err)
+}
+
+log.SetOutput(logstash.New(conn, map[string]interface{}{
+    "tags": []string{"vision-api"},
+}))
+
+log.Println("Hello!")
+```

--- a/main.go
+++ b/main.go
@@ -1,0 +1,33 @@
+package logstash
+
+// https://github.com/bobrik/logstasher/blob/master/writer.go
+import (
+	"encoding/json"
+	"io"
+	"time"
+)
+
+type Writer struct {
+	w      io.Writer
+	fields map[string]interface{}
+}
+
+func NewWriter(w io.Writer, f map[string]interface{}) Writer {
+	return Writer{
+		w:      w,
+		fields: f,
+	}
+}
+
+func (w Writer) Write(p []byte) (n int, err error) {
+	event := map[string]interface{}{
+		"@timestamp": time.Now(),
+		"message":    string(p),
+	}
+
+	for k, v := range w.fields {
+		event[k] = v
+	}
+
+	return len(p), json.NewEncoder(w.w).Encode(e)
+}

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ type Writer struct {
 	fields map[string]interface{}
 }
 
-func NewWriter(w io.Writer, f map[string]interface{}) Writer {
+func New(w io.Writer, f map[string]interface{}) Writer {
 	return Writer{
 		w:      w,
 		fields: f,
@@ -29,5 +29,5 @@ func (w Writer) Write(p []byte) (n int, err error) {
 		event[k] = v
 	}
 
-	return len(p), json.NewEncoder(w.w).Encode(e)
+	return len(p), json.NewEncoder(w.w).Encode(event)
 }


### PR DESCRIPTION
@projectweekend simple `io.Writer` that formats output for Logstash. Clients just need a `tcp.Conn` that is pointed to a Logstash instance to init.
